### PR TITLE
[test]<test> update crash_gen source to support set run path and  rep…

### DIFF
--- a/pytest/crash_gen/README.md
+++ b/pytest/crash_gen/README.md
@@ -24,7 +24,7 @@ This tool can also use to start a TDengine service, either in stand-alone mode o
 cluster mode. The features include:
 
 1. User specified number of D-Nodes to create/use.
-
+2. User can set run path  by -z or --set-path .
 # Preparation
 
 To run this tool, please ensure the followed preparation work is done first.
@@ -117,7 +117,7 @@ usage: crash_gen_bootstrap.py [-h] [-a] [-b MAX_DBS] [-c CONNECTOR_TYPE] [-d] [-
 TDengine Auto Crash Generator (PLEASE NOTICE the Prerequisites Below)
 ---------------------------------------------------------------------
 1. You build TDengine in the top level ./build directory, as described in offical docs
-2. You run the server there before this script: ./build/bin/taosd -c test/cfg
+2. You run the server there before this script: ./build/bin/taosd -c test/cfg ,you can also set run path by -v or --set-path
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -152,5 +152,8 @@ optional arguments:
   -w, --use-shadow-db   Use a shaddow database to verify data integrity (default: false)
   -x, --continue-on-exception
                         Continue execution after encountering unexpected/disallowed errors/exceptions (default: false)
+  -z SET_PATH, --set-path SET_PATH
+                        set crash_gen run path instead of defalut path
+                        
 ```
 

--- a/pytest/crash_gen/crash_gen_main.py
+++ b/pytest/crash_gen/crash_gen_main.py
@@ -2400,7 +2400,10 @@ class MainExec:
     def runClient(self):
         global gSvcMgr
         if Config.getConfig().auto_start_service:
-            gSvcMgr = self._svcMgr = ServiceManager(1) # hack alert
+            if Config.getConfig().num_dnodes>1: # multi taosd instance
+                gSvcMgr = self._svcMgr = ServiceManager(Config.getConfig().num_dnodes) # 
+            else:
+                gSvcMgr = self._svcMgr = ServiceManager(1) # hack alert ,single taosd instance
             gSvcMgr.startTaosServices() # we start, don't run
         
         self._clientMgr = ClientManager()
@@ -2426,7 +2429,7 @@ class MainExec:
                 TDengine Auto Crash Generator (PLEASE NOTICE the Prerequisites Below)
                 ---------------------------------------------------------------------
                 1. You build TDengine in the top level ./build directory, as described in offical docs
-                2. You run the server there before this script: ./build/bin/taosd -c test/cfg
+                2. You run the server there before this script: ./build/bin/taosd -c test/cfg ,you can also set run path by -v or --set-path
 
                 '''))                      
 
@@ -2539,6 +2542,13 @@ class MainExec:
             '--continue-on-exception',
             action='store_true',
             help='Continue execution after encountering unexpected/disallowed errors/exceptions (default: false)')
+        parser.add_argument(
+            '-z',
+            '--set-path',
+            action='store',
+            default='',
+            type=str,
+            help='set crash_gen run path instead of defalut path ')
 
         return parser
 

--- a/pytest/crash_gen/service_manager.py
+++ b/pytest/crash_gen/service_manager.py
@@ -166,7 +166,10 @@ quorum 2
         return self._buildDir + "/build/bin/taosd"
 
     def getRunDir(self) -> DirPath : # TODO: rename to "root dir" ?!
-        return DirPath(self._buildDir + self._subdir)
+        if Config.getConfig().set_path =='': # use default path
+            return DirPath(self._buildDir + self._subdir)
+        else:
+            return str(Config.getConfig().set_path)+self._subdir
 
     def getCfgDir(self) -> DirPath : # path, not file
         return DirPath(self.getRunDir() + "/cfg")


### PR DESCRIPTION
 update crash_gen source code  to support set run path  to let it can run in docker and without change files in 'debug' ,because the 'debug' directory in docker is mapped from host, it was not generated by itself, and any change about this directory will be synchronized across multiple docker instances ；

repair crash_gen auto deploy cluster instance 